### PR TITLE
Mark certain lifetimes as static

### DIFF
--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -217,7 +217,7 @@ impl Draft for Draft4 {
     }
 }
 
-pub fn draft_from_url(url: &str) -> Option<&Draft> {
+pub fn draft_from_url(url: &str) -> Option<&'static dyn Draft> {
     match url {
         "http://json-schema.org/draft-07/schema" => Some(&Draft7),
         "http://json-schema.org/draft-06/schema" => Some(&Draft6),
@@ -226,7 +226,7 @@ pub fn draft_from_url(url: &str) -> Option<&Draft> {
     }
 }
 
-pub fn draft_from_schema(schema: &Value) -> Option<&Draft> {
+pub fn draft_from_schema(schema: &Value) -> Option<&'static dyn Draft> {
     schema
         .as_object()
         .and_then(|x| x.get("$schema"))


### PR DESCRIPTION
Hi, hope you don't mind me opening a PR. I believe that the existing code of these two functions follows the lifetime elision rules such that, it assumes that the output `&Draft` will only live as long as the input references `&str` and `&Value`. By explicitly marking these as static, it allows them to be stored in structs and moved around freely, as opposed to just used as local variables.