### PR TITLE
Avoid boxing an empty iterator

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -72,21 +72,19 @@ impl<'a> Config<'a> {
 
     /// Validate the schema in this Config object against the metaschema.
     pub fn validate_schema(&'a self) -> Result<(), ErrorIterator<'a>> {
-        let mut errors = Box::new(
-            validators::descend(
-                self,
-                self.get_schema(),
-                self.get_metaschema(),
-                None,
-                Context::new_from(self.get_metaschema()),
-            )
-            .peekable(),
-        );
+        let mut errors = validators::descend(
+            self,
+            self.get_schema(),
+            self.get_metaschema(),
+            None,
+            Context::new_from(self.get_metaschema()),
+        )
+        .peekable();
 
         if errors.peek().is_none() {
             Ok(())
         } else {
-            Err(errors)
+            Err(Box::new(errors))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,21 +85,19 @@ pub fn validate<'a>(
     cfg: &'a config::Config<'a>,
     instance: &'a Value,
 ) -> Result<(), ErrorIterator<'a>> {
-    let mut errors = Box::new(
-        validators::descend(
-            cfg,
-            instance,
-            cfg.get_schema(),
-            None,
-            Context::new_from(cfg.get_schema()),
-        )
-        .peekable(),
-    );
+    let mut errors = validators::descend(
+        cfg,
+        instance,
+        cfg.get_schema(),
+        None,
+        Context::new_from(cfg.get_schema()),
+    )
+    .peekable();
 
     if errors.peek().is_none() {
         Ok(())
     } else {
-        Err(errors)
+        Err(Box::new(errors))
     }
 }
 


### PR DESCRIPTION
In the success case we can avoid the allocation.