### PR TITLE
Use an enum instead of a trait and trait objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Unreleased
 
 * Updated to comply with the latest version of the JSON Schema Test Suite.
+* **BREAKING CHANGE**: Draft versions are now an enum instead of a trait ([#13](https://github.com/mdboom/jsonschema-valid/pull/13))
+
+## Breaking changes
+
+### Draft versions are now an enum instead of a trait ([#13](https://github.com/mdboom/jsonschema-valid/pull/13))
+
+The API was changed to not require a trait for the draft version and instead use an enumeration of implemented draft versions.
+This simplifies usage slightly.
+
+Old:
+
+```rust
+let data: Value = serde_json::from_str(your_json_data)?;
+let cfg = jsonschema_valid::Config::from_schema(&schema, Some(&schemas::Draft6))?;
+```
+
+New:
+
+```rust
+let data: Value = serde_json::from_str(your_json_data)?;
+let cfg = jsonschema_valid::Config::from_schema(&schema, Some(schemas::Draft::Draft6))?;
+```
 
 # v0.3.0 (2019-02-26)
 

--- a/examples/threaded.rs
+++ b/examples/threaded.rs
@@ -1,0 +1,23 @@
+use jsonschema_valid::{schemas, Config};
+use lazy_static::lazy_static;
+use serde_json::Value;
+
+lazy_static! {
+    // Create the schema and schema validator globally once, then re-use them in multiple threads
+    // without problems.
+
+    static ref SCHEMA: Value = serde_json::from_str("{}").unwrap();
+    static ref SCHEMA_CFG: Config<'static> = Config::from_schema(&SCHEMA, Some(schemas::Draft::Draft6)).unwrap();
+}
+
+fn main() {
+    {
+        let data = serde_json::from_str("{}").unwrap();
+        assert!(SCHEMA_CFG.validate(&data).is_ok());
+    }
+
+    std::thread::spawn(|| {
+        let data = serde_json::from_str("{}").unwrap();
+        assert!(SCHEMA_CFG.validate(&data).is_ok());
+    });
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,12 +12,12 @@ use crate::validators::Validator;
 pub struct Config<'a> {
     schema: &'a Value,
     resolver: Resolver<'a>,
-    draft: &'a dyn schemas::Draft,
+    draft: schemas::Draft,
 }
 
 impl<'a> Config<'a> {
     /// Get the validator object for the draft in use.
-    pub fn get_validator(&self, key: &str) -> Option<Validator> {
+    pub fn get_validator<'v>(&self, key: &'v str) -> Option<Validator<'v>> {
         self.draft.get_validator(key)
     }
 
@@ -54,13 +54,13 @@ impl<'a> Config<'a> {
     /// by default.
     pub fn from_schema(
         schema: &'a Value,
-        draft: Option<&'a dyn schemas::Draft>,
+        draft: Option<schemas::Draft>,
     ) -> Result<Config<'a>, ValidationError> {
         Ok(Config {
             schema,
             resolver: Resolver::from_schema(schema)?,
             draft: draft.unwrap_or_else(|| {
-                schemas::draft_from_schema(schema).unwrap_or_else(|| &schemas::Draft7)
+                schemas::draft_from_schema(schema).unwrap_or_else(|| schemas::Draft::Draft7)
             }),
         })
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -135,7 +135,7 @@ mod tests {
         let schema = json!(
             { "properties": { "foo": { "type": "integer", "description": "HELLO" } } });
         let instance = json!({"foo": "string"});
-        let cfg = Config::from_schema(&schema, Some(&schemas::Draft6)).unwrap();
+        let cfg = Config::from_schema(&schema, Some(schemas::Draft::Draft6)).unwrap();
         let validation = cfg.validate(&instance);
 
         if let Err(errors) = validation {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! # let your_json_data = "{}";
 //! let schema: Value = serde_json::from_str(schema_json)?;
 //! let data: Value = serde_json::from_str(your_json_data)?;
-//! let cfg = jsonschema_valid::Config::from_schema(&schema, Some(&schemas::Draft6)).unwrap();
+//! let cfg = jsonschema_valid::Config::from_schema(&schema, Some(schemas::Draft::Draft6)).unwrap();
 //! // Validate the schema itself
 //! assert!(cfg.validate_schema().is_ok());
 //! // Validate a JSON instance against the schema
@@ -70,7 +70,7 @@ pub use crate::error::{ErrorIterator, ValidationError};
 /// # let your_json_data = "\"string\"";
 /// let schema: Value = serde_json::from_str(schema_json)?;
 /// let data: Value = serde_json::from_str(your_json_data)?;
-/// let cfg = jsonschema_valid::Config::from_schema(&schema, Some(&schemas::Draft6)).unwrap();
+/// let cfg = jsonschema_valid::Config::from_schema(&schema, Some(schemas::Draft::Draft6)).unwrap();
 ///
 /// let mut validation = jsonschema_valid::validate(&cfg, &data);
 /// if let Err(errors) = validation {
@@ -111,7 +111,7 @@ mod tests {
     // Test files we know will fail.
     const KNOWN_FAILURES: &'static [&'static str] = &["refRemote.json"];
 
-    fn test_draft(dirname: &str, draft: &dyn schemas::Draft) {
+    fn test_draft(dirname: &str, draft: schemas::Draft) {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("JSON-Schema-Test-Suite/tests");
         path.push(dirname);
@@ -161,16 +161,16 @@ mod tests {
 
     #[test]
     fn test_draft7() {
-        test_draft("draft7", &schemas::Draft7);
+        test_draft("draft7", schemas::Draft::Draft7);
     }
 
     #[test]
     fn test_draft6() {
-        test_draft("draft6", &schemas::Draft6);
+        test_draft("draft6", schemas::Draft::Draft6);
     }
 
     #[test]
     fn test_draft4() {
-        test_draft("draft4", &schemas::Draft4);
+        test_draft("draft4", schemas::Draft::Draft4);
     }
 }

--- a/src/validators.rs
+++ b/src/validators.rs
@@ -1131,7 +1131,7 @@ mod tests {
             "bar": "additional",
             "baz": "another additional"
         });
-        let cfg = Config::from_schema(&schema, Some(&schemas::Draft6)).unwrap();
+        let cfg = Config::from_schema(&schema, Some(schemas::Draft::Draft6)).unwrap();
         let validation = cfg.validate(&instance);
 
         if let Err(errors) = validation {


### PR DESCRIPTION
This is just as good as dynamic dispatch (a runtime branch to select the right functions), but makes it much easier to pass around (such as as a global static, see included example).

The current API is a bit cumbersome for users (see #10). This would fix it. It's a rather minimalistic change.

The only hard breaking change (apart from the slight syntax adoptions) is that previously it would have been possible for external users to implement new/alternative drafts, whereas after these changes the crate can only validate against the schemas we put into it.
IMO that's a feature, not a bug.

If we want to move forward with this I would need to add a changelog entry (and document steps to migrate old code to this).