### PR TITLE
Switch json-pointer to json-ptr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ regex = { version = "1.3", default-features = false, features = ["std"] }
 url = "2.1"
 chrono = "0.4"
 iri-string = "0.3"
-json-pointer = "0.3"
+json-ptr = "^0.3.4"
 percent-encoding = "2.1.0"
 textwrap = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonschema-valid-compat"
-version = "0.4.1-alpha.1"
+version = "0.4.1-alpha.2"
 authors = ["Michael Droettboom <mdroettboom@mozilla.org>"]
 description = "A simple JSON schema validator."
 repository = "https://github.com/mdboom/jsonschema-valid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/mdboom/jsonschema-valid"
 readme = "README.md"
 keywords = ["jsonschema"]
 license = "MPL-2.0"
-edition = "2018"
 
 [dependencies]
 serde_json = "1.0"
@@ -17,6 +16,6 @@ regex = { version = "1.3", default-features = false, features = ["std"] }
 url = "2.1"
 chrono = "0.4"
 iri-string = "0.3"
-json-ptr = "^0.3.4"
+json-ptr = "^0.3.5"
 percent-encoding = "2.1.0"
 textwrap = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonschema-valid-compat"
-version = "0.4.1-alpha.0"
+version = "0.4.1-alpha.1"
 authors = ["Michael Droettboom <mdroettboom@mozilla.org>"]
 description = "A simple JSON schema validator."
 repository = "https://github.com/mdboom/jsonschema-valid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jsonschema-valid"
+name = "jsonschema-valid-compat"
 version = "0.4.1-alpha.0"
 authors = ["Michael Droettboom <mdroettboom@mozilla.org>"]
 description = "A simple JSON schema validator."

--- a/examples/threaded.rs
+++ b/examples/threaded.rs
@@ -1,3 +1,6 @@
+extern crate serde_json;
+extern crate lazy_static;
+extern crate jsonschema_valid_compat as jsonschema_valid;
 use jsonschema_valid::{schemas, Config};
 use lazy_static::lazy_static;
 use serde_json::Value;

--- a/src/format.rs
+++ b/src/format.rs
@@ -61,7 +61,7 @@ pub fn time(_cfg: &Config, value: &str) -> bool {
 }
 
 pub fn json_pointer(_cfg: &Config, value: &str) -> bool {
-    value.parse::<json_pointer::JsonPointer<_, _>>().is_ok()
+    value.parse::<json_ptr::JsonPointer<_, _>>().is_ok()
 }
 
 pub fn uri_template(_cfg: &Config, _value: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@
 //! The following example validates some JSON data against a draft 6 JSON schema.
 //!
 //! ```rust
+//! # extern crate serde_json;
+//! # extern crate lazy_static;
+//! # extern crate jsonschema_valid_compat as jsonschema_valid;
 //! # fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
 //! # use serde_json::Value;
 //! # use jsonschema_valid::schemas;
@@ -24,8 +27,19 @@
 //!
 //! # Ok(()) }
 //! ````
-
 #![warn(missing_docs)]
+
+extern crate serde_json;
+extern crate lazy_static;
+extern crate itertools;
+extern crate regex;
+extern crate url;
+extern crate chrono;
+extern crate iri_string;
+extern crate json_ptr as json_pointer;
+extern crate percent_encoding;
+extern crate textwrap;
+
 
 use serde_json::Value;
 
@@ -63,6 +77,9 @@ pub use crate::error::{ErrorIterator, ValidationError};
 /// The following example validates some JSON data against a draft 6 JSON schema.
 ///
 /// ```rust
+/// # extern crate serde_json;
+/// # extern crate lazy_static;
+/// # extern crate jsonschema_valid_compat as jsonschema_valid;
 /// # fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
 /// # use serde_json::Value;
 /// # use jsonschema_valid::{schemas, Config};


### PR DESCRIPTION
A while back I made an attempt to patch json-pointer to support a lower MSRV so it would work with rust-bitcoin which requires 1.29. This request was not responded to & it kinda seems like the project is unmaintained.

I'd like to propose switching to json-ptr 0.3.4 which is just json-pointer with a lower serde pinned version.

see: https://gitlab.com/jmap-rs/json-pointer/-/issues/1

I didn't touch the version or the changelog, but this could be released as a patch. The json-pointer dependency was never exported pub in any interface, so this is a non-breaking change.